### PR TITLE
Fix scripts

### DIFF
--- a/bin/down
+++ b/bin/down
@@ -1,5 +1,5 @@
 #!/bin/bash
 hash mutagen-compose || exit 1
 
-basedir=$(dirname $0)
-mutagen-compose -f $basedir/../docker-compose.yml down
+basedir=$(readlink -f "$(dirname "$0")/..")
+mutagen-compose -f "$basedir/docker-compose.yml" down

--- a/bin/init
+++ b/bin/init
@@ -3,31 +3,31 @@ hash git || exit 1
 hash mutagen-compose || exit 1
 trap 'exit 1' INT QUIT
 
-basedir=$(dirname $0)
-servicesdir=$(readlink -f $basedir/../services)
-composefile=$basedir/../docker-compose.yml
+basedir=$(readlink -f "$(dirname "$0")/..")
+servicesdir=$basedir/services
+composefile=$basedir/docker-compose.yml
 bright='\033[1;37m'
 reset='\033[0m'
 
 echo -e "\n${bright}Cloning source repositories${reset}\n"
-git clone https://github.com/mozilla/reticulum.git $servicesdir/reticulum
-git clone https://github.com/mozilla/dialog.git $servicesdir/dialog
-git clone https://github.com/mozilla/hubs.git $servicesdir/hubs
-git clone https://github.com/mozilla/Spoke.git $servicesdir/spoke
+git clone https://github.com/mozilla/reticulum.git "$servicesdir/reticulum"
+git clone https://github.com/mozilla/dialog.git "$servicesdir/dialog"
+git clone https://github.com/mozilla/hubs.git "$servicesdir/hubs"
+git clone https://github.com/mozilla/Spoke.git "$servicesdir/spoke"
 
 echo -e "\n${bright}Initializing Reticulum${reset}\n"
-mutagen-compose -f $composefile run --rm reticulum sh -c 'mix do deps.get, deps.compile, ecto.create'
+mutagen-compose -f "$composefile" run --rm reticulum sh -c 'mix do deps.get, deps.compile, ecto.create'
 
 echo -e "\n${bright}Initializing Dialog${reset}\n"
-mutagen-compose -f $composefile run --rm dialog sh -c '[ -d "node_modules" ] || npm ci'
+mutagen-compose -f "$composefile" run --rm dialog sh -c '[ -d "node_modules" ] || npm ci'
 
 echo -e "\n${bright}Initializing Hubs Admin${reset}\n"
-mutagen-compose -f $composefile run --rm hubs-admin sh -c '[ -d "node_modules" ] || npm ci'
+mutagen-compose -f "$composefile" run --rm hubs-admin sh -c '[ -d "node_modules" ] || npm ci'
 
 echo -e "\n${bright}Initializing Hubs Client${reset}\n"
-mutagen-compose -f $composefile run --rm hubs-client sh -c '[ -d "node_modules" ] || npm ci'
+mutagen-compose -f "$composefile" run --rm hubs-client sh -c '[ -d "node_modules" ] || npm ci'
 
 echo -e "\n${bright}Initializing Spoke${reset}\n"
-mutagen-compose -f $composefile run --rm spoke yarn
+mutagen-compose -f "$composefile" run --rm spoke yarn
 
 mutagen-compose down

--- a/bin/observe
+++ b/bin/observe
@@ -3,7 +3,7 @@ hash docker-compose || exit 1
 hash tmux || exit 1
 hash watch || exit 1
 
-basedir=$(dirname $0)
+basedir=$(readlink -f "$(dirname "$0")/..")
 session='hubs-compose'
 window=0
 
@@ -14,7 +14,7 @@ else
 fi
 
 tmux rename-window -t $session:$window 'observer'
-tmux send-keys -t $session:$window "watch docker-compose -f $basedir/../docker-compose.yml ps" C-m
+tmux send-keys -t $session:$window "watch 'docker-compose -f \'$basedir/docker-compose.yml\' ps'" C-m
 tmux split-window -t $session:$window
-tmux send-keys -t $session:$window "docker-compose -f $basedir/../docker-compose.yml logs --follow --timestamps --tail='all'" C-m
+tmux send-keys -t $session:$window "docker-compose -f '$basedir/docker-compose.yml' logs --follow --timestamps --tail='all'" C-m
 tmux attach-session -t $session

--- a/bin/observe
+++ b/bin/observe
@@ -14,7 +14,7 @@ else
 fi
 
 tmux rename-window -t $session:$window 'observer'
-tmux send-keys -t $session:$window "watch 'docker-compose -f \'$basedir/docker-compose.yml\' ps'" C-m
+tmux send-keys -t $session:$window "watch \"docker-compose -f '$basedir/docker-compose.yml' ps\"" C-m
 tmux split-window -t $session:$window
 tmux send-keys -t $session:$window "docker-compose -f '$basedir/docker-compose.yml' logs --follow --timestamps --tail='all'" C-m
 tmux attach-session -t $session

--- a/bin/reset
+++ b/bin/reset
@@ -1,7 +1,7 @@
 #!/bin/bash
 hash mutagen-compose || exit 1
 
-basedir=$(dirname $0)
-mutagen-compose -f $basedir/../docker-compose.yml down --volumes --rmi local
-rm -rf $basedir/../services/reticulum/deps
-$basedir/init
+basedir=$(readlink -f "$(dirname "$0")/..")
+mutagen-compose -f "$basedir/docker-compose.yml" down --volumes --rmi local
+rm -r "$basedir/services/reticulum/deps"
+"$basedir/bin/init"

--- a/bin/up
+++ b/bin/up
@@ -1,5 +1,5 @@
 #!/bin/bash
 hash mutagen-compose || exit 1
 
-basedir=$(dirname $0)
-mutagen-compose -f $basedir/../docker-compose.yml up --build --detach
+basedir=$(readlink -f "$(dirname "$0")/..")
+mutagen-compose -f "$basedir/docker-compose.yml" up --build --detach


### PR DESCRIPTION
Why
---

On a fresh install the initialization script may fail with a read-only
file system error.  This is because `readlink` is being invoked on the
services directory before it exists.

When the path contains a space all of the scripts break.  This is
because the commands treat the path as multiple arguments.

What
----

* Apply `readlink` to a directory that is sure to exist
* Quote paths