### PR TITLE
Fix unhealthy Dialog status

### DIFF
--- a/dockerfiles/dialog.Dockerfile
+++ b/dockerfiles/dialog.Dockerfile
@@ -2,6 +2,7 @@
 ARG NODE_VERSION=12.9
 
 FROM --platform=linux/amd64 node:${NODE_VERSION} AS dev
+HEALTHCHECK CMD curl -f http://localhost:7000/meta || exit 1
 COPY files/dev-perms.pub.pem /etc/perms.pub.pem
 COPY services/reticulum/priv/dev-ssl.cert /etc/ssl/fullchain.pem
 COPY services/reticulum/priv/dev-ssl.key /etc/ssl/privkey.pem

--- a/dockerfiles/dialog.Dockerfile
+++ b/dockerfiles/dialog.Dockerfile
@@ -2,7 +2,6 @@
 ARG NODE_VERSION=12.9
 
 FROM --platform=linux/amd64 node:${NODE_VERSION} AS dev
-HEALTHCHECK CMD curl -fk https://localhost:4443/meta || exit 1
 COPY files/dev-perms.pub.pem /etc/perms.pub.pem
 COPY services/reticulum/priv/dev-ssl.cert /etc/ssl/fullchain.pem
 COPY services/reticulum/priv/dev-ssl.key /etc/ssl/privkey.pem


### PR DESCRIPTION
Why
---

The public `/meta` path from Dialog is being used as a health-check.
When that path was removed from Dialog the health-check broke.

What
----

* Remove broken health-check