### PR TITLE
Start storybook when the stack is run

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,6 +56,17 @@ services:
     volumes:
       - hubs:/code
     working_dir: /code
+  hubs-storybook:
+    build:
+      context: .
+      dockerfile: dockerfiles/hubs.Dockerfile
+      target: dev
+    command: npm run storybook
+    ports:
+      - "6006:6006"
+    volumes:
+      - hubs:/code
+    working_dir: /code
   postgrest:
     build:
       context: .


### PR DESCRIPTION
### Why
When working on UI updates is pretty common to working on the components in an atomic and isolated way and storybook is pretty handy for that. Having storybook run with the whole stack might be useful.

### What
Start storybook when the stack is run.