### PR TITLE
Use custom network

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -96,6 +96,9 @@ services:
       - "9090:9090"
     volumes:
       - spoke:/code
+networks:
+  default:
+    name: mozilla-hubs
 volumes:
   dialog:
   hubs:

--- a/dockerfiles/reticulum.Dockerfile
+++ b/dockerfiles/reticulum.Dockerfile
@@ -4,7 +4,7 @@ ARG ELIXIR_VERSION=1.8.2
 ARG OTP_VERSION=22.3.4
 
 FROM hexpm/elixir:${ELIXIR_VERSION}-erlang-${OTP_VERSION}-alpine-${ALPINE_LINUX_VERSION} AS dev
-HEALTHCHECK CMD wget --no-check-certificate https://localhost:4000/health -O /dev/null || exit 1
+HEALTHCHECK CMD wget --no-check-certificate https://localhost:4000/link -O /dev/null || exit 1
 RUN mix do local.hex --force, local.rebar --force
 RUN apk add --no-cache\
     # required by hex\


### PR DESCRIPTION
Why
---

I want to hook other projects up to Hubs over the same network

What
----

Create the `mozilla-hubs` network