### PR TITLE
Add config to skip mutagen dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,27 @@ shell using the scripts inside the given service’s `bin/` directory.  For
 example, calling `bin/mix deps.get` from `./services/reticulum/` will download
 the dependencies for Reticulum.
 
+### Running without mutagen
+
+Mutagen and mutagen-compose are especially useful on MacOS (and Windows?), where docker's bind mounts do not perform well. If you prefer to use bind mounts, you can override the defaults by merging in the `docker-compose-bind-mounts.yml` file:
+
+```sh
+docker compose \
+    -f "docker-compose.yml" \
+    -f "docker-compose-bind-mounts.yml" \
+    up
+```
+
+To perform first-time setup, you will also want to merge in the `docker-compose-init.yml` file:
+
+```sh
+docker compose \
+    -f "docker-compose.yml" \
+    -f "docker-compose-bind-mounts.yml" \
+    -f "docker-compose-init.yml" \
+    up
+```
+
 ## Development
 
 ### Architectural Decision Records

--- a/docker-compose-bind-mounts.yml
+++ b/docker-compose-bind-mounts.yml
@@ -1,0 +1,27 @@
+version: "3.9"
+services:
+  dialog:
+    volumes:
+      - type: bind
+        source: ./services/dialog
+        target: /code
+  hubs-admin:
+    volumes:
+      - type: bind
+        source: ./services/hubs
+        target: /code
+  hubs-client:
+    volumes:
+      - type: bind
+        source: ./services/hubs
+        target: /code
+  reticulum:
+    volumes:
+      - type: bind
+        source: ./services/reticulum
+        target: /code
+  spoke:
+    volumes:
+      - type: bind
+        source: ./services/spoke
+        target: /code

--- a/docker-compose-init.yml
+++ b/docker-compose-init.yml
@@ -1,0 +1,12 @@
+version: "3.9"
+services:
+  dialog:
+    command: sh -c "npm ci && npm start"
+  hubs-admin:
+    command: sh -c "npm ci && npm run local"
+  hubs-client:
+    command: sh -c "npm ci && npm run local"
+  reticulum:
+    command: sh -c "mix do deps.get, deps.compile, ecto.create && PERMS_KEY=$$(cat /etc/perms.pem) mix phx.server"
+  spoke:
+    command: sh -c "yarn install && ./scripts/run-local-reticulum.sh"


### PR DESCRIPTION
### What
Add a config file (`docker-compose-bind-mounts.yml`) that can be merged with `docker-compose.yml` to avoid `mutagen` and `mutagen-compose` dependencies.

### Why
Mutagen and mutagen-compose are especially useful on MacOS (and Windows?), where docker's bind mounts do not perform well, but don't seem necessary on linux.

The scripts in `bin/` still call `mutagen-compose`, but I thought this would still be worth sharing for Linux users who may be familiar with docker but not mutagen.