### PR TITLE
Clone source on first init only

### DIFF
--- a/bin/init
+++ b/bin/init
@@ -10,10 +10,10 @@ bright='\033[1;37m'
 reset='\033[0m'
 
 echo -e "\n${bright}Cloning source repositories${reset}\n"
-git clone https://github.com/mozilla/reticulum.git "$servicesdir/reticulum"
-git clone https://github.com/mozilla/dialog.git "$servicesdir/dialog"
-git clone https://github.com/mozilla/hubs.git "$servicesdir/hubs"
-git clone https://github.com/mozilla/Spoke.git "$servicesdir/spoke"
+[ -d "$servicesdir/reticulum" ] || git clone https://github.com/mozilla/reticulum.git "$servicesdir/reticulum"
+[ -d "$servicesdir/dialog" ] || git clone https://github.com/mozilla/dialog.git "$servicesdir/dialog"
+[ -d "$servicesdir/hubs" ] || git clone https://github.com/mozilla/hubs.git "$servicesdir/hubs"
+[ -d "$servicesdir/spoke" ] || git clone https://github.com/mozilla/Spoke.git "$servicesdir/spoke"
 
 echo -e "\n${bright}Initializing Reticulum${reset}\n"
 mutagen-compose -f "$composefile" run --rm reticulum sh -c 'mix do deps.get, deps.compile, ecto.create'


### PR DESCRIPTION
**Disclaimer:** I'm still quite unfamiliar with all this so there is probably a much better solution for this or it might just not make sense at all.

### Why
When working with containers there might be times when I want to init the contianer (after a npm ci) but I don't what to delete the source folder as that will revert it to master.

### What
This PR will only clone the source on the first repo init if the source code folder doens't exist.
