### PR TITLE
Fix Spoke, etc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ Hubs Compose is a Docker Compose setup than can be used to orchestrate all the
 services used by Mozilla Hubs for local development.[^1]
 
 [^1]: This is not a production-ready setup.  It does not account for
-security or scalability.  Additionally the permissions files were generated for development purposes only.
+security or scalability.  Additionally the permissions files were generated for
+development purposes only.
 
 ## Usage
 
@@ -34,21 +35,22 @@ certificates, you can visit https://hubs.local:4000 from your browser.
 ### Self-Signed Certificates
 
 Service communication is encrypted with self-signed Transport Layer Security
-(TLS) certificates.  You will need to accept the certificate at each of the
-ports mapped in [`docker-compose.yml`](docker-compose.yml).  At the time of this
-writing, that means visiting these links in your web browser and following the
-prompts:
+(TLS) certificates.  You will need to accept the proxy certificate and the
+certificate at each of the Hubs ports mapped in
+[`docker-compose.yml`](docker-compose.yml).  At the time of this writing, that
+means visiting these links in your web browser and following the prompts:
 
-* [4443: Dialog](https://hubs.local:4443)
-* [9090: Spoke](https://hubs.local:9090)
-* [8989: Hubs Admin](https://hubs.local:8989)
-* [8080: Hubs Client](https://hubs.local:8080)
-* [4000: Reticulum](https://hubs.local:4000)
+* [Proxy](https://hubs-proxy.local:4000)
+* [Dialog](https://hubs.local:4443)
+* [Spoke](https://hubs.local:9090)
+* [Hubs Admin](https://hubs.local:8989)
+* [Hubs Client](https://hubs.local:8080)
+* [Reticulum](https://hubs.local:4000)
 
 ### Admin panel access
 
-To connect to the admin panel you will need to manually promote an account to admin:
-https://github.com/mozilla/reticulum#6-creating-an-admin-user
+To connect to the admin panel you will need to manually
+[promote an account to admin](https://github.com/mozilla/reticulum#6-creating-an-admin-user).
 
 ### Command Execution
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,6 +62,8 @@ services:
       dockerfile: dockerfiles/hubs.Dockerfile
       target: dev
     command: npm run storybook
+    healthcheck:
+      test: ["CMD", "curl", "-fk", "http://hubs.local:6006"]
     ports:
       - "6006:6006"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,10 +3,10 @@ services:
   db:
     environment:
       POSTGRES_PASSWORD: postgres
-      POSTGRES_USER: postgres
     healthcheck:
       test: ["CMD", "pg_isready"]
     image: "postgres:14-alpine"
+    user: postgres
     volumes:
       - pgdata:/var/lib/postgresql/data
   dialog:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -104,6 +104,7 @@ services:
       target: dev
     command: ./scripts/run-local-reticulum.sh
     environment:
+      CORS_PROXY_SERVER: "hubs-proxy.local:4000"
       INTERNAL_HOSTNAME: spoke
     ports:
       - "9090:9090"

--- a/dockerfiles/reticulum.Dockerfile
+++ b/dockerfiles/reticulum.Dockerfile
@@ -4,7 +4,7 @@ ARG ELIXIR_VERSION=1.8.2
 ARG OTP_VERSION=22.3.4
 
 FROM hexpm/elixir:${ELIXIR_VERSION}-erlang-${OTP_VERSION}-alpine-${ALPINE_LINUX_VERSION} AS dev
-HEALTHCHECK CMD wget --no-check-certificate https://localhost:4000/link -O /dev/null || exit 1
+HEALTHCHECK CMD wget --no-check-certificate --no-verbose --tries=1 --spider https://localhost:4000/stream-offline.png
 RUN mix do local.hex --force, local.rebar --force
 RUN apk add --no-cache\
     # required by hex\


### PR DESCRIPTION
Why
---

When loading assets Spoke emits this error:

> Error loading glTF root: Cause: Network Error: Unknown Status. Unknown
> Error. Possibly a CORS error.

This is because Spoke uses https://hubs-proxy.com/ as a CORS proxy.

What
----

Configure Spoke to use local CORS proxy

Also
----

* Add health check to hubs-storybook
* Add proxy instructions to README
* Update Reticulum health check
* Run db service under postgres instead of root