### PR TITLE
Fix ^C and ^\ behavior in bin/init

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,5 +3,6 @@
 !files/dev-perms.pub.pem
 !files/dev-reticulum-jwk.json
 !files/dev-reticulum.conf
+!files/trapped-mix
 !services/reticulum/priv/dev-ssl.cert
 !services/reticulum/priv/dev-ssl.key

--- a/bin/down
+++ b/bin/down
@@ -1,3 +1,3 @@
 #!/bin/bash
 basedir=$(dirname "$0")/..
-mutagen-compose -f "$basedir/docker-compose.yml" down
+mutagen-compose -f "$basedir"/docker-compose.yml down

--- a/bin/init
+++ b/bin/init
@@ -1,27 +1,27 @@
 #!/bin/bash
 hash mutagen-compose || exit 1
 
-basedir=$(readlink -f "$(dirname "$0")/..")
+basedir=$(readlink -f "$(dirname "$0")"/..)
+prefix='\n\033[1;37m'
+suffix='\033[0m\n'
+
 servicesdir=$basedir/services
+echo -e ${prefix}Cloning source repositories$suffix
+git clone https://github.com/mozilla/reticulum.git "$servicesdir"/reticulum
+git clone https://github.com/mozilla/dialog.git "$servicesdir"/dialog
+git clone https://github.com/mozilla/hubs.git "$servicesdir"/hubs
+git clone https://github.com/mozilla/Spoke.git "$servicesdir"/spoke
+
 composefile=$basedir/docker-compose.yml
-bright='\033[1;37m'
-reset='\033[0m'
-
-echo -e "\n${bright}Cloning source repositories${reset}\n"
-git clone https://github.com/mozilla/reticulum.git "$servicesdir/reticulum"
-git clone https://github.com/mozilla/dialog.git "$servicesdir/dialog"
-git clone https://github.com/mozilla/hubs.git "$servicesdir/hubs"
-git clone https://github.com/mozilla/Spoke.git "$servicesdir/spoke"
-
-echo -e "\n${bright}Initializing Reticulum${reset}\n" &&
+echo -e ${prefix}Initializing Reticulum$suffix &&
 mutagen-compose -f "$composefile" run --rm reticulum sh -c 'mix do deps.get, deps.compile, ecto.create' &&
-echo -e "\n${bright}Initializing Dialog${reset}\n" &&
+echo -e ${prefix}Initializing Dialog$suffix &&
 mutagen-compose -f "$composefile" run --rm dialog sh -c '[ -d "node_modules" ] || npm ci' &&
-echo -e "\n${bright}Initializing Hubs Admin${reset}\n" &&
+echo -e ${prefix}Initializing Hubs Admin$suffix &&
 mutagen-compose -f "$composefile" run --rm hubs-admin sh -c '[ -d "node_modules" ] || npm ci' &&
-echo -e "\n${bright}Initializing Hubs Client${reset}\n" &&
+echo -e ${prefix}Initializing Hubs Client$suffix &&
 mutagen-compose -f "$composefile" run --rm hubs-client sh -c '[ -d "node_modules" ] || npm ci' &&
-echo -e "\n${bright}Initializing Spoke${reset}\n" &&
+echo -e ${prefix}Initializing Spoke$suffix &&
 mutagen-compose -f "$composefile" run --rm spoke yarn
 
 code=$?

--- a/bin/init
+++ b/bin/init
@@ -14,7 +14,8 @@ git clone https://github.com/mozilla/Spoke.git "$servicesdir"/spoke
 
 composefile=$basedir/docker-compose.yml
 echo -e ${prefix}Initializing Reticulum$suffix &&
-mutagen-compose -f "$composefile" run --rm reticulum sh -c 'mix do deps.get, deps.compile, ecto.create' &&
+docker-compose -f "$composefile" build reticulum &&
+mutagen-compose -f "$composefile" run --rm reticulum sh -c 'trapped-mix do deps.get, deps.compile, ecto.create' &&
 echo -e ${prefix}Initializing Dialog$suffix &&
 mutagen-compose -f "$composefile" run --rm dialog sh -c '[ -d "node_modules" ] || npm ci' &&
 echo -e ${prefix}Initializing Hubs Admin$suffix &&

--- a/bin/observe
+++ b/bin/observe
@@ -2,7 +2,7 @@
 hash docker-compose || exit 1
 hash watch || exit 1
 
-basedir=$(readlink -f "$(dirname "$0")/..")
+basedir=$(readlink -f "$(dirname "$0")"/..)
 session='hubs-compose'
 window=0
 
@@ -12,8 +12,8 @@ else
   tmux new-session -d -s $session
 fi
 
-tmux rename-window -t $session:$window 'observer'
-tmux send-keys -t $session:$window "watch \"docker-compose -f '$basedir/docker-compose.yml' ps\"" C-m
+tmux rename-window -t $session:$window observer
+tmux send-keys -t $session:$window "watch docker-compose -f \'$basedir/docker-compose.yml\' ps" C-m
 tmux split-window -t $session:$window
-tmux send-keys -t $session:$window "docker-compose -f '$basedir/docker-compose.yml' logs --follow --timestamps --tail='all'" C-m
+tmux send-keys -t $session:$window "docker-compose -f '$basedir/docker-compose.yml' logs --follow --timestamps" C-m
 tmux attach-session -t $session

--- a/bin/reset
+++ b/bin/reset
@@ -1,6 +1,6 @@
 #!/bin/bash
-basedir=$(readlink -f "$(dirname "$0")/..")
+basedir=$(readlink -f "$(dirname "$0")"/..)
 
-mutagen-compose -f "$basedir/docker-compose.yml" down --volumes --rmi local &&
-rm -rf "$basedir/services/reticulum/deps" &&
-"$basedir/bin/init"
+mutagen-compose -f "$basedir"/docker-compose.yml down --volumes --rmi local &&
+rm -rf "$basedir"/services/reticulum/deps &&
+"$basedir"/bin/init

--- a/bin/up
+++ b/bin/up
@@ -1,3 +1,3 @@
 #!/bin/bash
 basedir=$(dirname "$0")/..
-mutagen-compose -f "$basedir/docker-compose.yml" up --build --detach
+mutagen-compose -f "$basedir"/docker-compose.yml up --build --detach

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,7 @@ services:
       INTERNAL_HOSTNAME: hubs-admin
     healthcheck:
       test: ["CMD", "curl", "-fk", "https://localhost:8989/admin.html"]
+    platform: linux/amd64
     ports:
       - "8989:8989"
     volumes:
@@ -51,6 +52,7 @@ services:
     healthcheck:
       start_period: 3m30s
       test: ["CMD", "curl", "-fk", "https://localhost:8080"]
+    platform: linux/amd64
     ports:
       - "8080:8080"
     volumes:
@@ -64,6 +66,7 @@ services:
     command: npm run storybook
     healthcheck:
       test: ["CMD", "curl", "-fk", "http://hubs.local:6006"]
+    platform: linux/amd64
     ports:
       - "6006:6006"
     volumes:
@@ -106,6 +109,7 @@ services:
     environment:
       CORS_PROXY_SERVER: "hubs-proxy.local:4000"
       INTERNAL_HOSTNAME: spoke
+    platform: linux/amd64
     ports:
       - "9090:9090"
     volumes:

--- a/dockerfiles/dialog.Dockerfile
+++ b/dockerfiles/dialog.Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 ARG NODE_VERSION=12.9
 
-FROM --platform=linux/amd64 node:${NODE_VERSION} AS dev
+FROM node:${NODE_VERSION} AS dev
 HEALTHCHECK CMD curl -f http://localhost:7000/meta || exit 1
 COPY files/dev-perms.pub.pem /etc/perms.pub.pem
 COPY services/reticulum/priv/dev-ssl.cert /etc/ssl/fullchain.pem

--- a/dockerfiles/reticulum.Dockerfile
+++ b/dockerfiles/reticulum.Dockerfile
@@ -12,4 +12,5 @@ RUN apk add --no-cache\
     # required by hex:phoenix_live_reload\
     inotify-tools
 COPY files/dev-perms.pem /etc/perms.pem
+COPY files/trapped-mix /usr/local/bin/trapped-mix
 WORKDIR /code

--- a/files/trapped-mix
+++ b/files/trapped-mix
@@ -1,0 +1,3 @@
+#!/bin/sh
+trap 'exit 130' INT QUIT
+mix "$@"


### PR DESCRIPTION
Why
---
If I send the interrupt (^C) or quit (^\) signal while bin/init is initializing Reticulum, the other services will be initialized.  This is because `mix` does not return exit codes.

What
----
* Create a wrapper `trapped-mix` for mix that traps SIGINT and SIGQUIT
* Use `trapped-mix` in `bin/init`
* Build container images during initialization to pick up on dockerfile changes
* Restrain double-quotes in orchestration scripts