### PR TITLE
Upgrade elixir image for reticulum

### DIFF
--- a/dockerfiles/reticulum.Dockerfile
+++ b/dockerfiles/reticulum.Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
-ARG ALPINE_LINUX_VERSION=3.13.1
-ARG ELIXIR_VERSION=1.8.2
-ARG OTP_VERSION=22.3.4
+ARG ALPINE_LINUX_VERSION=3.16.2
+ARG ELIXIR_VERSION=1.14.3
+ARG OTP_VERSION=23.3.4.18
 
 FROM hexpm/elixir:${ELIXIR_VERSION}-erlang-${OTP_VERSION}-alpine-${ALPINE_LINUX_VERSION} AS dev
 HEALTHCHECK CMD wget --no-check-certificate --no-verbose --tries=1 --spider https://localhost:4000/stream-offline.png


### PR DESCRIPTION
Reticulum upgrades its elixir version to `1.14` in https://github.com/mozilla/reticulum/pull/664 . Bump the elixir docker image for reticulum in this project to match.

`.tool-versions`: https://github.com/mozilla/reticulum/blob/dd14e634699d72c2640b459b31778551feed6e75/.tool-versions#L1-L2
hexpm search: https://hub.docker.com/r/hexpm/elixir/tags?page=1&name=1.14.3-erlang-23.3.4.18-alpine