### PR TITLE
Add extra_hosts 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,10 @@ services:
     volumes:
       - hubs:/code
     working_dir: /code/admin
+    extra_hosts:
+      - "hubs.local:host-gateway"
+      - "hubs-proxy.local:host-gateway"
+      - "host.docker.internal:host-gateway"
   hubs-client:
     build:
       context: .
@@ -58,6 +62,10 @@ services:
     volumes:
       - hubs:/code
     working_dir: /code
+    extra_hosts:
+      - "hubs.local:host-gateway"
+      - "hubs-proxy.local:host-gateway"
+      - "host.docker.internal:host-gateway"
   hubs-storybook:
     build:
       context: .
@@ -100,6 +108,10 @@ services:
     volumes:
       - reticulum:/code
       - retstorage:/code/storage/dev
+    extra_hosts:
+      - "hubs.local:host-gateway"
+      - "hubs-proxy.local:host-gateway"
+      - "host.docker.internal:host-gateway"
   spoke:
     build:
       context: .
@@ -114,6 +126,10 @@ services:
       - "9090:9090"
     volumes:
       - spoke:/code
+    extra_hosts:
+      - "hubs.local:host-gateway"
+      - "hubs-proxy.local:host-gateway"
+      - "host.docker.internal:host-gateway"
 networks:
   default:
     name: mozilla-hubs


### PR DESCRIPTION
For local development, we have been mapping `hubs.local` to `localhost` via entries in the hostfile (`/etc/hosts`). With this docker setup, the services are running in separate containers and thus should not map to `localhost` for cross-service traffic. 

Add `extra_hosts` so that `hubs.local` and `hubs-proxy.local` resolve to the `host-gateway` and containers can reach one another. It seems that `host.docker.internal` also only works for me (on linux) if it is included as an `extra_host`. 

I don't know if this is the correct solution. I was inspired in part by this stackoverflow answer https://stackoverflow.com/a/70725882 , which also comes with a large warning and recommendation to define a custom `network` definition that will guarantee a specific gateway address. 