### PR TITLE
Make dependency installation more deterministic

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 *
+!files/conditional-npm-ci
 !files/dev-perms.pub.pem
 !files/dev-reticulum-jwk.json
 !files/dev-reticulum.conf

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ certificates, you can visit https://hubs.local:4000 from your browser.
 * Observe running containers with `bin/observe`[^2]
 * Restore all services to a fresh state with `bin/reset`
 * Update all service source code with `bin/services-update`
+* Update service dependencies with `bin/init`
 
 [^2]: Requires `tmux` and `watch` program files in the user’s path
 

--- a/bin/init
+++ b/bin/init
@@ -18,11 +18,13 @@ docker-compose -f "$composefile" build reticulum &&
 mutagen-compose -f "$composefile" run --rm reticulum sh -c 'trapped-mix do deps.get, deps.compile, ecto.create' &&
 echo -e ${prefix}Initializing Dialog$suffix &&
 docker-compose -f "$composefile" build dialog &&
-mutagen-compose -f "$composefile" run --rm dialog npm install --no-save &&
+mutagen-compose -f "$composefile" run --rm dialog conditional-npm-ci &&
 echo -e ${prefix}Initializing Hubs Admin$suffix &&
-mutagen-compose -f "$composefile" run --rm hubs-admin npm install --no-save &&
+docker-compose -f "$composefile" build hubs-admin &&
+mutagen-compose -f "$composefile" run --rm hubs-admin conditional-npm-ci &&
 echo -e ${prefix}Initializing Hubs Client$suffix &&
-mutagen-compose -f "$composefile" run --rm hubs-client npm install --no-save &&
+docker-compose -f "$composefile" build hubs-client &&
+mutagen-compose -f "$composefile" run --rm hubs-client conditional-npm-ci &&
 echo -e ${prefix}Initializing Spoke$suffix &&
 mutagen-compose -f "$composefile" run --rm spoke yarn install
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -123,6 +123,7 @@ x-mutagen:
           - ".gitignore"
           - "/certs/"
           - "/node_modules/"
+          - "package-lock.sha512"
         vcs: true
       mode: "two-way-resolved"
     dialog:

--- a/dockerfiles/dialog.Dockerfile
+++ b/dockerfiles/dialog.Dockerfile
@@ -6,6 +6,7 @@ HEALTHCHECK CMD curl -f http://localhost:7000/meta || exit 1
 RUN apt-get update && apt-get install -y \
   python3-pip \
   && rm -rf /var/lib/apt/lists/*
+COPY files/conditional-npm-ci /usr/local/bin/conditional-npm-ci
 COPY files/dev-perms.pub.pem /etc/perms.pub.pem
 COPY services/reticulum/priv/dev-ssl.cert /etc/ssl/fullchain.pem
 COPY services/reticulum/priv/dev-ssl.key /etc/ssl/privkey.pem

--- a/dockerfiles/hubs.Dockerfile
+++ b/dockerfiles/hubs.Dockerfile
@@ -2,3 +2,4 @@
 ARG NODE_VERSION=16.16
 
 FROM --platform=linux/amd64 node:${NODE_VERSION}
+COPY files/conditional-npm-ci /usr/local/bin/conditional-npm-ci

--- a/files/conditional-npm-ci
+++ b/files/conditional-npm-ci
@@ -1,0 +1,7 @@
+#!/bin/sh
+checksum='package-lock.sha512'
+
+if ! sha512sum --check --status $checksum 2>/dev/null; then
+  npm ci
+  sha512sum package-lock.json > $checksum
+fi


### PR DESCRIPTION
Fixes https://github.com/mozilla/hubs-compose/issues/34

Why
---
Although `npm install --no-save` doesn’t alter `package-lock.json`, it doesn’t honor `package-lock.json` any more than `npm install`.  The clean install `npm ci` is time-consuming and should only be run if `package-lock.json` has changed.

How
---
* Create `conditional-npm-ci`
* Use `conditional-npm-ci` for Dialog, Hubs Admin, and Hubs Client