### PR TITLE
Add Makefile for more easy management of /bin/init script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,58 @@
+basedir=$(PWD)
+servicesdir=$(basedir)/services
+composefile=$(basedir)/docker-compose.yml
+prefix=\n\033[1;37m
+suffix=\033[0m\n
+
+all: init
+
+.PHONY: check
+check:
+	hash mutagen-compose || exit 1
+
+.PHONY: clone
+clone:
+	@printf "$(prefix)Cloning source repositories$(suffix)"
+	git clone https://github.com/mozilla/reticulum.git $(servicesdir)/reticulum
+	git clone https://github.com/mozilla/dialog.git $(servicesdir)/dialog
+	git clone https://github.com/mozilla/hubs.git $(servicesdir)/hubs
+	git clone https://github.com/mozilla/Spoke.git $(servicesdir)/spoke
+
+.PHONY: reticulum
+reticulum:
+	@printf "$(prefix)Initializing Reticulum$(suffix)" && \
+	docker-compose -f $(composefile) build reticulum && \
+	mutagen-compose -f $(composefile) run --rm reticulum sh -c 'trapped-mix do deps.get, deps.compile, ecto.create'
+
+.PHONY: dialog
+dialog:
+	@printf "$(prefix)Initializing Dialog$(suffix)" && \
+	docker-compose -f $(composefile) build dialog && \
+	mutagen-compose -f $(composefile) run --rm dialog conditional-npm-ci
+
+.PHONY: hubs-admin
+hubs-admin:
+	@printf "$(prefix)Initializing Hubs Admin$(suffix)" && \
+	docker-compose -f $(composefile) build hubs-admin && \
+	mutagen-compose -f $(composefile) run --rm hubs-admin conditional-npm-ci
+
+.PHONY: hubs-client
+hubs-client:
+	@printf "$(prefix)Initializing Hubs Client$(suffix)" && \
+	docker-compose -f $(composefile) build hubs-client && \
+	mutagen-compose -f $(composefile) run --rm hubs-client conditional-npm-ci
+
+.PHONY: spoke
+spoke:
+	@printf "$(prefix)Initializing Spoke$(suffix)" && \
+	mutagen-compose -f $(composefile) run --rm spoke yarn install
+
+.PHONY: init
+init: check clone reticulum dialog hubs-admin hubs-client spoke
+	@printf "$(prefix)Done$(suffix)" && \
+	mutagen-compose down
+
+.PHONY: clean
+clean:
+	rm -rf $(servicesdir)
+


### PR DESCRIPTION
Why
/bin scripts is very convenient, but I feel like the readability is low.

What
I had an idea that using a Makefile for more easy management and improve readability, so I tried replacing the /bin/init scripts first. 